### PR TITLE
Added missing .npmignore file

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,4 @@
+/nbproject
+/bower_components
+node_modules
+npm-debug.log


### PR DESCRIPTION
### Problem

The latest version of the `leaflet.offline` NPM package (v1.0.1) is broken upon installation.

```sh
slurm@comp:~/code/leaflet.offline-test$ npm install leaflet.offline
npm notice created a lockfile as package-lock.json. You should commit this file.
npm WARN leaflet.offline-test@1.0.0 No description
npm WARN leaflet.offline-test@1.0.0 No repository field.

+ leaflet.offline@1.0.1
added 5 packages in 3.857s

slurm@comp:~/code/leaflet.offline-test$ node
> const offline = require('leaflet.offline')
Error: Cannot find module 'leaflet.offline'
    at Function.Module._resolveFilename (module.js:538:15)
    at Function.Module._load (module.js:468:25)
    at Module.require (module.js:587:17)
    at require (internal/module.js:11:18)
> 
(To exit, press ^C again or type .exit)
> 
```

When you try to `require` the module Node will complain that it doesn't exist (the main/entry script is defined as `dist/bundle.js`).

This is happening because the `dist` directory is no longer in git and is therefore not being deployed to NPM when you publish. This issue was introduced in https://github.com/allartk/leaflet.offline/commit/1377a453084193bdc210d235fee1b749bfcb2c90.

When an `.npmignore` file is not defined, [NPM will fall back to the `.gitignore` file](https://docs.npmjs.com/misc/developers#keeping-files-out-of-your-package), which in this case is explicitly ignoring the `dist` directory.

The user can technically circumvent the issue by digging into `./node_modules/leaflet.offline` and running `npm install && npm run build` from there, but this is a non-idiomatic and intrusive workaround.

### Solution

I introduced a `.npmignore` file that matches `.gitignore` except that it does **not** include an entry for `dist`. This is a common pattern that allows you to avoid version controlling bundles in Git.

This means that `dist` will be deployed to NPM every time you perform an `npm publish`.

The only downside is every time you make a change to `.gitignore` you will want to be sure that `.npmignore` is updated appropriately (risk of data drift and human error).