### PR TITLE
Added TMS support

### DIFF
--- a/src/ControlSaveTiles.js
+++ b/src/ControlSaveTiles.js
@@ -170,7 +170,9 @@ const ControlSaveTiles = L.Control.extend(
           this._map.project(latlngBounds.getNorthWest(), zoomlevels[i]),
           this._map.project(latlngBounds.getSouthEast(), zoomlevels[i]),
         );
-        tiles = tiles.concat(this._baseLayer.getTileUrls(bounds, zoomlevels[i]));
+        tiles = tiles.concat(
+          this._baseLayer.getTileUrls(bounds, zoomlevels[i], this._map.options.crs),
+        );
       }
       this._resetStatus(tiles);
       const successCallback = async () => {

--- a/src/TileLayerOffline.js
+++ b/src/TileLayerOffline.js
@@ -1,6 +1,8 @@
 import L from 'leaflet';
 import { getTileUrls, getTileUrl, getTile } from './TileManager';
 
+const noop = () => { };
+
 /**
  * A layer that uses stored tiles when available. Falls back to online.
  *
@@ -26,7 +28,7 @@ const TileLayerOffline = L.TileLayer.extend(
      */
     createTile(coords, done) {
       let error;
-      const tile = L.TileLayer.prototype.createTile.call(this, coords, () => {});
+      const tile = L.TileLayer.prototype.createTile.call(this, coords, noop);
       const url = tile.src;
       tile.src = '';
       this.setDataUrl(coords)

--- a/src/TileManager.js
+++ b/src/TileManager.js
@@ -131,9 +131,16 @@ export function getTileUrls(layer, bounds, zoom) {
   );
   for (let j = tileBounds.min.y; j <= tileBounds.max.y; j += 1) {
     for (let i = tileBounds.min.x; i <= tileBounds.max.x; i += 1) {
-      const tilePoint = new L.Point(i, j);
+      const x = i;
+      let y = j;
+      // invert y coordinate for TMS tile schemes
+      const invertedY = this._globalTileRange.max.y - y;
+      if (layer.options.tms) {
+        y = invertedY;
+      }
+      const tilePoint = new L.Point(i, y);
       const data = {
-        ...layer.options, x: i, y: j, z: zoom,
+        ...layer.options, x, y, z: zoom,
       };
       tiles.push({
         key: getTileUrl(layer._url, {
@@ -145,9 +152,10 @@ export function getTileUrls(layer, bounds, zoom) {
           s: layer._getSubdomain(tilePoint),
         }),
         z: zoom,
-        x: i,
-        y: j,
+        x,
+        y,
         urlTemplate: layer._url,
+        '-y': invertedY,
       });
     }
   }

--- a/src/TileManager.js
+++ b/src/TileManager.js
@@ -120,21 +120,23 @@ export function getTileUrl(urlTemplate, data) {
  * @param {object} layer leaflet tilelayer
  * @param {object} bounds L.bounds
  * @param {number} zoom zoomlevel 0-19
+ * @param {L.CRS} [crs] to calculate the world pixel bounds for TMS scheme
  *
  * @return {Array.<tileInfo>}
  */
-export function getTileUrls(layer, bounds, zoom) {
+export function getTileUrls(layer, bounds, zoom, crs = L.CRS.EPSG3857) {
   const tiles = [];
   const tileBounds = L.bounds(
     bounds.min.divideBy(layer.getTileSize().x).floor(),
     bounds.max.divideBy(layer.getTileSize().x).floor(),
   );
+  const worldTileBounds = layer._pxBoundsToTileRange(crs.getProjectedBounds(zoom));
   for (let j = tileBounds.min.y; j <= tileBounds.max.y; j += 1) {
     for (let i = tileBounds.min.x; i <= tileBounds.max.x; i += 1) {
       const x = i;
       let y = j;
       // invert y coordinate for TMS tile schemes
-      const invertedY = this._globalTileRange.max.y - y;
+      const invertedY = worldTileBounds.max.y - y;
       if (layer.options.tms) {
         y = invertedY;
       }

--- a/test/TileLayerTest.js
+++ b/test/TileLayerTest.js
@@ -16,7 +16,7 @@ describe('TileLayer.Offline', () => {
   it('createTile', () => {
     const url = 'http://a.tile.openstreetmap.org/{z}/{x}/{y}.png';
     const layer = L.tileLayer.offline(url);
-    const tile = layer.createTile({ x: 123456, y: 456789, z: 16 }, () => {});
+    const tile = layer.createTile({ x: 123456, y: 456789, z: 16 }, () => { });
     assert.instanceOf(tile, HTMLElement);
   });
   it('get storagekey openstreetmap', () => {
@@ -56,6 +56,20 @@ describe('TileLayer.Offline', () => {
     assert.include(urls, 'http://a.tile.openstreetmap.org/16/33677/21651.png');
     const keys = tiles.map((t) => t.key);
     assert.include(keys, 'http://a.tile.openstreetmap.org/16/33677/21651.png');
+  });
+
+  it('takes into account TMS option', () => {
+    const layer = L.tileLayer.offline('http://a.tile.openstreetmap.org/{z}/{x}/{y}.png', { tms: true });
+    const bounds = new L.Bounds(
+      new L.Point(8621975, 5543267.999999999),
+      new L.Point(8621275, 5542538),
+    );
+    const tiles = layer.getTileUrls(bounds, 16);
+    assert.lengthOf(tiles, 16);
+    const urls = tiles.map((t) => t.url);
+    assert.include(urls, 'http://a.tile.openstreetmap.org/16/33676/43885.png');
+    const keys = tiles.map((t) => t.key);
+    assert.include(keys, 'http://a.tile.openstreetmap.org/16/33676/43885.png');
   });
 
   it('calculates tile urls,keys at level 16 with subdomains', () => {


### PR DESCRIPTION
The URL request code was ignoring the `tms` option (inverted Y-axis in tile grid)
https://leafletjs.com/examples/wms/wms.html (scroll to bottom)

I added a fix for that (borrowing the logic from the [original `L.TileLayer` code](https://github.com/Leaflet/Leaflet/blob/master/src/layer/tile/TileLayer.js#L177))
Unfortunately, I couldn't find an openly available TMS service to test it, so I did a somewhat blind fix

I had to add an optional parameter to `getTileUrls()`, passing the CRS so that it can calculate world tile bounds for TMS, not depending directly on the current map state, and so that it was easily testable