### PR TITLE
don't use the database during download

### DIFF
--- a/src/TileLayerOffline.js
+++ b/src/TileLayerOffline.js
@@ -17,6 +17,22 @@ import { getTileUrls, getTileUrl, getTile } from './TileManager';
  */
 const TileLayerOffline = L.TileLayer.extend(
   /** @lends  TileLayerOffline */ {
+
+    _ongoingSave: false,
+
+  	initialize: function (url, options) {
+
+      this._url = url;
+      options = L__default["default"].Util.setOptions(this, options);
+
+      this.on('savestart', () => {
+       this._ongoingSave = true;
+      });
+      this.on('saveend', () => {
+        this._ongoingSave = false;
+       });
+    },  
+
     /**
      * Create tile HTMLElement
      * @private
@@ -60,6 +76,8 @@ const TileLayerOffline = L.TileLayer.extend(
      * @return {Promise<string>} objecturl
      */
     setDataUrl(coords) {
+      if(this._ongoingSave) return Promise.resolve().then(() => {throw new Error('On download state');});
+
       return getTile(this._getStorageKey(coords)).then((data) => {
         if (data && typeof data === 'object') {
           return URL.createObjectURL(data);

--- a/src/TileLayerOffline.js
+++ b/src/TileLayerOffline.js
@@ -23,7 +23,7 @@ const TileLayerOffline = L.TileLayer.extend(
   	initialize: function (url, options) {
 
       this._url = url;
-      options = L__default["default"].Util.setOptions(this, options);
+      options = L.Util.setOptions(this, options);
 
       this.on('savestart', () => {
        this._ongoingSave = true;

--- a/src/TileLayerOffline.js
+++ b/src/TileLayerOffline.js
@@ -17,21 +17,19 @@ import { getTileUrls, getTileUrl, getTile } from './TileManager';
  */
 const TileLayerOffline = L.TileLayer.extend(
   /** @lends  TileLayerOffline */ {
-
     _ongoingSave: false,
 
-  	initialize: function (url, options) {
-
+    initialize(url, options) {
       this._url = url;
-      options = L.Util.setOptions(this, options);
+      L.setOptions(this, options);
 
       this.on('savestart', () => {
-       this._ongoingSave = true;
+        this._ongoingSave = true;
       });
       this.on('saveend', () => {
         this._ongoingSave = false;
-       });
-    },  
+      });
+    },
 
     /**
      * Create tile HTMLElement
@@ -76,7 +74,10 @@ const TileLayerOffline = L.TileLayer.extend(
      * @return {Promise<string>} objecturl
      */
     setDataUrl(coords) {
-      if(this._ongoingSave) return Promise.resolve().then(() => {throw new Error('On download state');});
+      if (this._ongoingSave)
+        return Promise.resolve().then(() => {
+          throw new Error('On download state');
+        });
 
       return getTile(this._getStorageKey(coords)).then((data) => {
         if (data && typeof data === 'object') {

--- a/src/TileLayerOffline.js
+++ b/src/TileLayerOffline.js
@@ -75,9 +75,7 @@ const TileLayerOffline = L.TileLayer.extend(
      */
     setDataUrl(coords) {
       if (this._ongoingSave)
-        return Promise.resolve().then(() => {
-          throw new Error('On download state');
-        });
+        return Promise.reject(new Error('On download state'));
 
       return getTile(this._getStorageKey(coords)).then((data) => {
         if (data && typeof data === 'object') {


### PR DESCRIPTION
The use of the database during the download process means that the display of the map in real time may be altered. 
The goal in this case is to download the images.
At the end of the process, the database is used again