### PR TITLE
Support node 18

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: 18
           check-latest: true
 
       - name: Cache dependencies

--- a/docs/package.json
+++ b/docs/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "engines": {
-    "node": "16.x"
+    "node": "^16 || ^18"
   },
   "scripts": {
     "jekyll": "docker-compose up",

--- a/docs/package.json
+++ b/docs/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "engines": {
-    "node": "^16 || ^18"
+    "node": ">=16"
   },
   "scripts": {
     "jekyll": "docker-compose up",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Offline tilelayer for leaflet",
   "main": "dist/bundle.js",
   "engines": {
-    "node": "16.x"
+    "node": "^16 || ^18"
   },
   "types": "dist/types/src/index.d.ts",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Offline tilelayer for leaflet",
   "main": "dist/bundle.js",
   "engines": {
-    "node": "^16 || ^18"
+    "node": ">=16"
   },
   "types": "dist/types/src/index.d.ts",
   "scripts": {


### PR DESCRIPTION
Hi, I am trying to leaflet.offline on an app that uses node 18.x and the engine set in package.json make it incompatible with version of node other than 16.

I'm not sure if this PR is the correct way to fix this, just trying to help