### PR TITLE
Fix/handle-out-of-bounds-tiles

### DIFF
--- a/src/TileManager.ts
+++ b/src/TileManager.ts
@@ -83,8 +83,8 @@ export async function getStorageInfo(
  */
 export async function downloadTile(tileUrl: string): Promise<Blob> {
   const response = await fetch(tileUrl);
-  if (!response.ok) {
-    throw new Error(`Request failed with status ${response.statusText}`);
+  if (!response.ok && response.status !== 400) {
+    throw new Error(`Request failed with status ${response.status} ${response.statusText} for ${tileUrl}`);
   }
   return response.blob();
 }


### PR DESCRIPTION
* Do not throw exception on tile fetch when response status is 400
* 400 on OpenStreetMaps and GeoServer means that you are out of bounds
* Thus allowing to count correctly the retrieved tiles and fire saveend

This is a common scenario when retrieving tiles beyond zoom level 19 on openstreetmaps and from other servers too.
I followed the least changes approach.
The saved blob, does not get rendered from leaflet. We can also return a null sized image blob.

Thanks for the time to review it.