### PR TITLE
feat: added additional export from tilemanager to index

### DIFF
--- a/src/TileLayerOffline.ts
+++ b/src/TileLayerOffline.ts
@@ -9,7 +9,6 @@ import {
 } from 'leaflet';
 import {
   getTileUrl,
-  getBlobByKey,
   TileInfo,
   getTilePoints,
   getTileImageSource,

--- a/src/TileManager.ts
+++ b/src/TileManager.ts
@@ -6,7 +6,7 @@
  *
  */
 
-import { Bounds, Browser, CRS, GridLayer, Point, Util } from 'leaflet';
+import { Bounds, Browser, CRS, Point, Util } from 'leaflet';
 import { openDB, deleteDB, IDBPDatabase } from 'idb';
 import { FeatureCollection, Polygon } from 'geojson';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,8 +15,9 @@ export {
   truncate,
   downloadTile,
   saveTile,
+  hasTile,
   getBlobByKey,
   getTilePoints,
   getTileUrl,
-  getTileImageSource
+  getTileImageSource,
 } from './TileManager';

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,4 +16,7 @@ export {
   downloadTile,
   saveTile,
   getBlobByKey,
+  getTilePoints,
+  getTileUrl,
+  getTileImageSource
 } from './TileManager';

--- a/test/TileManagerTest.ts
+++ b/test/TileManagerTest.ts
@@ -1,5 +1,6 @@
 /* global describe, it, assert, beforeEach */
-import { point, bounds, GridLayer, gridLayer } from 'leaflet';
+import { point, bounds, gridLayer } from 'leaflet';
+import fetchMock from 'fetch-mock/esm/client';
 import {
   downloadTile,
   getStorageInfo,
@@ -12,7 +13,6 @@ import {
   saveTile,
   truncate,
 } from '../src/TileManager';
-import fetchMock from 'fetch-mock/esm/client';
 
 const testTileInfo = {
   url: 'https://api.tiles.mapbox.com/v4/mapbox.streets/16/33677/21651.png?access_token=xyz',


### PR DESCRIPTION
Added:

- ```getTilePoints```,
- ```getTileUrl```,
- ```getTileImageSource```
- ```hasTile```

to ```index.ts``` as an export from ```TileManager.ts```.

I am developing a plugin to this library which supports vector offline tile rendering and therefore, I require these functions to be part of the export in ```index.ts```.